### PR TITLE
Add requirements.txt to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include AUTHORS.md LICENSE README.md
+include requirements.txt


### PR DESCRIPTION
Otherwise, `pip install leeroy` results in `IOError: [Errno 2] No such file or directory: requirements.txt`
