### PR TITLE
Fix SERVER_NAME when a proxy is present

### DIFF
--- a/leeroy/github.py
+++ b/leeroy/github.py
@@ -70,7 +70,9 @@ def update_status(app, repo_config, repo_name, sha, state, desc,
 
 def register_github_hooks(app):
     with app.app_context():
-        github_endpoint = url_for("base.github_notification", _external=True)
+        github_endpoint = "http://%s%s" % (
+                app.config["GITHUB_NOTIFICATION_SERVER_NAME"],
+                url_for("base.github_notification", _external=False))
 
     for repo_config in app.config["REPOSITORIES"]:
         repo_name = repo_config["github_repo"]
@@ -78,8 +80,10 @@ def register_github_hooks(app):
         response = requests.get(url, auth=get_github_auth(app, repo_config))
 
         if not response.ok:
-            logging.warn("Unable to install GitHub hook for repo %s: %s %s",
-                         repo_name, response.status_code, response.reason)
+            logging.warn("Unable to install GitHub hook for repo %s "
+                         "with url %s: %s %s",
+                         repo_name, github_endpoint, response.status_code,
+                         response.reason)
             continue
 
         found_hook = False

--- a/leeroy/settings.py
+++ b/leeroy/settings.py
@@ -2,9 +2,13 @@ DEBUG = True
 LOGGING_CONF = "logging.conf"
 LOGGER_NAME = "leeroy"
 
-# The hostname (and :port, if necessary) of this server, used for
-# the GitHub hook
+# The hostname (and :port, if necessary) of this server
 SERVER_NAME = "leeroy.example.com"
+
+# The hostname (and :port, if necessary) of the server GitHub should send
+# notification to. It can be different from SERVER_NAME when another server is
+# proxying requests to leeroy.
+GITHUB_NOTIFICATION_SERVER_NAME = SERVER_NAME
 
 # GitHub configuration
 GITHUB_USER = "octocat"


### PR DESCRIPTION
The idea behind this commit is that since `SERVER_NAME` is a Flask builtin variable, it can lead to issues when using a proxy to redirect calls to leeroy.

If you put `SERVER_NAME = "127.0.0.1"`, obviously creating the hook callback URL won't work. And if you put `SERVER_NAME = "ci.whatever.com"`, Flask will return 404 for any request because it's not the adress it's serving on.
