### PR TITLE
Verify that notifications originate from GitHub

### DIFF
--- a/leeroy/base.py
+++ b/leeroy/base.py
@@ -3,7 +3,7 @@
 import logging
 
 from flask import Blueprint, current_app, json, request, Response, abort
-from werkzeug.exceptions import NotFound
+from werkzeug.exceptions import NotFound, Forbidden
 
 from . import github, jenkins
 
@@ -93,6 +93,10 @@ def jenkins_notification():
 
 @base.route("/notification/github", methods=["POST"])
 def github_notification():
+    whitelist = current_app.config.get("WEBHOOK_ADDRESS_WHITELIST")
+    if whitelist and not request.remote_addr in whitelist:
+        raise Forbidden("Webhook address not in whitelist")
+
     action = request.json["action"]
     pull_request = request.json["pull_request"]
     number = pull_request["number"]

--- a/leeroy/settings.py
+++ b/leeroy/settings.py
@@ -23,6 +23,16 @@ JENKINS_PASSWORD = ""
 # or only one for the last one.
 BUILD_ALL_COMMITS = True
 
+# Only accept Webhook POST requests that originate from these addresses. Set
+# to something falsy to disable whitelisting.
+WEBHOOK_ADDRESS_WHITELIST = [
+    "127.0.0.1",
+    # GitHub
+    "207.97.227.253",
+    "50.57.128.197",
+    "108.171.174.178"
+]
+
 # A list of dicts containing configuration for each GitHub repository &
 # Jenkins job pair you want to join together.
 #


### PR DESCRIPTION
According to GitHub, WebHook POSTs should only ever come from a handful
of addresses. This patch rejects any request that doesn't. If GitHub
changes these addresses in the future, users can adjust their settings
rather than waiting for a new version of leeroy. This feature can be
disabled by setting `WEBHOOK_ADDRESS_WHITELIST` to something falsy.

(The addresses in question are listed on the Service Hooks page.)
