### PR TITLE
Fix _parse_jenkins_json to handle application/json content-type.

### DIFF
--- a/leeroy/base.py
+++ b/leeroy/base.py
@@ -27,7 +27,7 @@ def _parse_jenkins_json(request):
             # Seems bad that there's only 1 key, but press on
             return request.form
     else:
-        return request.form
+        return request.json
 
 
 @base.route("/notification/jenkins", methods=["POST"])


### PR DESCRIPTION
With Jenkins Notification plugin 1.5, the content-type appears to be set
correctly to application/json. This change should work with previous versions
that set it to application/x-www-form-urlencoded.
