### PR TITLE
Initiate build when PR is reopened.

### DIFF
--- a/leeroy/base.py
+++ b/leeroy/base.py
@@ -103,7 +103,7 @@ def github_notification():
                   "%s %s (%s): %s",
                   base_repo_name, number, html_url, action)
 
-    if action not in ("opened", "synchronize"):
+    if action not in ("opened", "reopened", "synchronize"):
         logging.debug("Ignored '%s' action." % action)
         return Response(status=204)
 


### PR DESCRIPTION
When a PR has been reopened, kick off another build for the commit(s). This
also helps address issue #9 as you can close/reopen a PR to force a rebuild.
