### PR TITLE
Use GET instead of POST for Jenkins build request.

### DIFF
--- a/leeroy/jenkins.py
+++ b/leeroy/jenkins.py
@@ -35,6 +35,6 @@ def schedule_build(app, repo_config, head_repo_name, sha, html_url):
                           github_url=html_url)
 
     logging.debug("Requesting build from Jenkins: %s", url)
-    response = requests.post(url, auth=get_jenkins_auth(app, repo_config))
+    response = requests.get(url, auth=get_jenkins_auth(app, repo_config))
     logging.debug("Jenkins responded with status code %s",
                   response.status_code)


### PR DESCRIPTION
I don't know why this isn't a problem for anyone else. When leeroy makes build request to Jenkins using POST, it fails with a status 411 from Jenkins. The reason for the 411 is the POST has no content-length. The error in leeroy's log looks like the following.

```
Requesting build from Jenkins: http://jenkins.example.com/job/leeroy-testing/buildWithParameters?GIT_BASE_REPO=cluther/leeroy-testing&GIT_HEAD_REPO=cluther/leeroy-testing&GIT_SHA1=a00f4cae71d5b7399bd8c43fd04bad2b2dc32dc4&GITHUB_URL=https://github.com/cluther/leeroy-testing/pull/1
Jenkins responded with status code 411
```

Changing the POST to a GET fixes it. Considering there's no data in the post, it doesn't seem like this would cause problems.
