### PR TITLE
format was failing

### DIFF
--- a/leeroy/cron.py
+++ b/leeroy/cron.py
@@ -31,7 +31,7 @@ def retry_jenkins(repo_config, pull_request):
     pr_number = pull_request['number']
     html_url = pull_request["html_url"]
     sha = pull_request['head']['sha']
-    log.debug("Creating a new Jenkins job for {}".format(pr_number))
+    log.debug("Creating a new Jenkins job for {0}".format(pr_number))
     head_repo_name, shas = github.get_commits(app, repo_config, pull_request)
     schedule_build(app, repo_config, head_repo_name, sha, html_url)
 


### PR DESCRIPTION
This was the stacktrace

```
Traceback (most recent call last):
  File "/usr/local/bin/leeroy-cron", line 9, in <module>
    load_entry_point('leeroy==0.2.0', 'console_scripts', 'leeroy-cron')()
  File "/usr/local/lib/python2.6/dist-packages/leeroy/cron.py", line 59, in main
    retry_jenkins(repo_config, pull_request)
  File "/usr/local/lib/python2.6/dist-packages/leeroy/cron.py", line 34, in retry_jenkins
    log.debug("Creating a new Jenkins job for {}".format(pr_number))
ValueError: zero length field name in format
```
