### PR TITLE
Fixed empty brace problems

### DIFF
--- a/leeroy/cron.py
+++ b/leeroy/cron.py
@@ -31,7 +31,7 @@ def retry_jenkins(repo_config, pull_request):
     pr_number = pull_request['number']
     html_url = pull_request["html_url"]
     sha = pull_request['head']['sha']
-    log.debug("Creating a new Jenkins job for {}".format(pr_number))
+    log.debug("Creating a new Jenkins job for {0}".format(pr_number))
     head_repo_name, shas = github.get_commits(app, repo_config, pull_request)
     schedule_build(app, repo_config, head_repo_name, sha, html_url)
 

--- a/leeroy/github.py
+++ b/leeroy/github.py
@@ -222,7 +222,7 @@ def get_pull_request(app, repo_config, pull_request):
     :param pull_request: the pull request number
     """
     response = get_api_response(
-        app, repo_config, "/repos/{{repo_name}}/pulls/{}".format(pull_request))
+        app, repo_config, "/repos/{{repo_name}}/pulls/{0}".format(pull_request))
     return response.json
 
 

--- a/leeroy/retry.py
+++ b/leeroy/retry.py
@@ -17,7 +17,7 @@ def main():
     parser.add_argument('pull_request', type=int)
     args = parser.parse_args()
 
-    log.info("Scheduling a build for PR {}".format(args.pull_request))
+    log.info("Scheduling a build for PR {0}".format(args.pull_request))
     repo_config = github.get_repo_config(app, args.repo)
     pull_request = github.get_pull_request(app, repo_config, args.pull_request)
     head_repo_name, shas = github.get_commits(app, repo_config, pull_request)


### PR DESCRIPTION
This was the stacktrace without my fix.

```
Traceback (most recent call last):
  File "/usr/local/bin/leeroy-cron", line 9, in <module>
    load_entry_point('leeroy==0.2.0', 'console_scripts', 'leeroy-cron')()
  File "/usr/local/lib/python2.6/dist-packages/leeroy/cron.py", line 59, in main
    retry_jenkins(repo_config, pull_request)
  File "/usr/local/lib/python2.6/dist-packages/leeroy/cron.py", line 34, in retry_jenkins
    log.debug("Creating a new Jenkins job for {}".format(pr_number))
ValueError: zero length field name in format
```

Ubuntu/Python 2.6
