### PR TITLE
Adds a JENKINS_VERIFY option to settings.py

### DIFF
--- a/leeroy/jenkins.py
+++ b/leeroy/jenkins.py
@@ -57,6 +57,7 @@ def schedule_build(app, repo_config, head_repo_name, sha, html_url):
         url += "&token=" + build_token
 
     logging.debug("Requesting build from Jenkins: %s", url)
-    response = requests.post(url, auth=get_jenkins_auth(app, repo_config))
+    response = requests.post(url, auth=get_jenkins_auth(app, repo_config),
+                             verify=app.config["JENKINS_VERIFY"])
     logging.debug("Jenkins responded with status code %s",
                   response.status_code)

--- a/leeroy/settings.py
+++ b/leeroy/settings.py
@@ -21,6 +21,12 @@ GITHUB_API_BASE = "https://api.github.com"
 # Enterprise with a self signed certificate.
 GITHUB_VERIFY = True
 
+# Verify SSL certificate for Jenkins server. Always set this to True unless
+# using Jenkins with a self signed certificate. Optionally use a path
+# to the Jenkins CA bundle.
+# JENKINS_VERIFY = "/etc/nginx/ssl/"
+JENKINS_VERIFY = True
+
 # Create and use a GitHub API token or supply a user and password.
 GITHUB_TOKEN = ""
 # GITHUB_USER = "octocat"


### PR DESCRIPTION
When running Jenkins under SSL with a self-signed certificate, it
can be difficult for leeroy to make the build request. Using the
JENKINS_VERIFY options allows us to bypass the certificate check.

This can be helpful if your jenkins server runs under a private domain name.